### PR TITLE
fix in README example with ensure version package

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In hiera:
 ```
 package::package:
   bash:
-    version: 4.2.theonewiththeshellshockpatches
+    ensure: 4.2.theonewiththeshellshockpatches
   git: {}
 ```
 


### PR DESCRIPTION
Installation of specific package version with ensure not version parameter. Version parameter is not defined.
